### PR TITLE
Use public HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "sideEffects": false,
-  "repository": "git@github.com:ninjagains/use-abortable-promise.git",
+  "repository": "git+https://github.com/ninjagains/use-abortable-promise.git",
   "keywords": [
     "AbortController",
     "react",


### PR DESCRIPTION
This updates the npm package repository metadata to use a public HTTPS Git URL instead of the current SSH/SCP-style URL.

Current value:

```json
"repository": "git@github.com:ninjagains/use-abortable-promise.git"
```

Updated value:

```json
"repository": "git+https://github.com/ninjagains/use-abortable-promise.git"
```

This is a metadata-only change:
- no runtime code changes
- no dependency changes
- no version or entrypoint changes

Validation:
- confirmed the current `package.json` fails an assertion expecting the public HTTPS repository URL
- confirmed this branch passes the same assertion
- confirmed the compare contains one commit and only changes `package.json`